### PR TITLE
Use 'position_gps' rather than 'GPS' for 15

### DIFF
--- a/jobs/15.js
+++ b/jobs/15.js
@@ -6,9 +6,9 @@ upsert(
     field('ampi__Description__c', dataValue('form.@name')),
     field(
       'Location__latitude__s',
-      state => state.data.form.GPS.split(' ')[0]
+      state => state.data.form.position_gps.split(' ')[0]
     ),
-    field('Location__longitude__s', state => state.data.form.GPS.split(' ')[1]),
+    field('Location__longitude__s', state => state.data.form.position_gps.split(' ')[1]),
     field('Submission_ID__c', dataValue('id')),
     relationship(
       'Project__r',


### PR DESCRIPTION
Hi @Izelledupisanie (cc: @aleksa-krolls ) , job 15 is failing because there doesn't seem to be a `form.GPS` key in the [message data](https://github.com/OpenFn/Tostan-CommCare-Amp/blob/master/test/data/15-state.json#L132) from CommCare. Is it possible that Vera meant to map `form.position_gps` instead, or should we expect to see that `form.GPS` data to come in intermittently? If it's the former, I'll need to make this GPS field conditional. If it's the latter, please see my suggested change and merge at your discretion.